### PR TITLE
Fix typo and small error

### DIFF
--- a/source/Maptools安装与配置/安装依赖库.rst
+++ b/source/Maptools安装与配置/安装依赖库.rst
@@ -30,6 +30,7 @@ Maptool的依赖库包括:
     pip install networkx
     pip install ppq
     pip install matplotlib
+    pip install cython
 
 .. note::
 

--- a/source/使用Maptools执行模型映射/执行Tile映射 (逻辑映射).rst
+++ b/source/使用Maptools执行模型映射/执行Tile映射 (逻辑映射).rst
@@ -24,7 +24,7 @@ Tile映射的全部流程都被集成到 :py:data:`TileMapper` 这个 `class` �
     tm.run_map()
 
     # 打印Tile映射信息
-    tm.print_config()
+    tm.report_config()
 
     # 获得映射得到的CTG
     ctg = tm.ctg


### PR DESCRIPTION
add cython as a dependency of maptools.
fixed a typo in tile mapping.